### PR TITLE
fix: Don't use `args` when spawning child processes, resolves DEP0190

### DIFF
--- a/src/tools/eslint.ts
+++ b/src/tools/eslint.ts
@@ -2,23 +2,14 @@ import type { OutputParser, Problem, ToolDefinition } from "../types";
 import { execAndParse } from "../utils";
 
 export const eslint: ToolDefinition = ({ root }) => {
-  const bin = "eslint";
-  const checkArgs = [
-    ".",
-    "--ext",
-    ".js,.ts,.jsx,.tsx,.mjs,.mts,.cjs,.cts,.vue",
-    "--format",
-    "compact",
-    "--max-warnings",
-    "0",
-  ];
-  const fixArgs = [...checkArgs, "--fix"];
+  const checkCmd = `eslint . --ext .js,.ts,.jsx,.tsx,.mjs,.mts,.cjs,.cts,.vue --format compact --max-warnings 0`;
+  const fixCmd = `${checkCmd} --fix`;
 
   return {
     name: "ESLint",
     packageName: "eslint",
-    check: () => execAndParse(bin, checkArgs, root, parseOutput),
-    fix: () => execAndParse(bin, fixArgs, root, parseOutput),
+    check: () => execAndParse(checkCmd, root, parseOutput),
+    fix: () => execAndParse(fixCmd, root, parseOutput),
   };
 };
 

--- a/src/tools/markdownlint.ts
+++ b/src/tools/markdownlint.ts
@@ -2,22 +2,15 @@ import type { OutputParser, ToolDefinition } from "../types";
 import { execAndParse } from "../utils";
 
 export const markdownlint: ToolDefinition = ({ root }) => {
-  const bin = "markdownlint";
-  const checkArgs = [
-    ".",
-    "--json",
-    "--ignore='**/dist/**'",
-    "--ignore='**/node_modules/**'",
-    "--ignore='**/.output/**'",
-    "--ignore='**/coverage/**'",
-  ];
-  const fixArgs = [...checkArgs, "--fix"];
+  const checkCmd =
+    "markdownlint . --json --ignore='**/dist/**' --ignore='**/node_modules/**' --ignore='**/.output/**' --ignore='**/coverage/**'";
+  const fixCmd = `${checkCmd} --fix`;
 
   return {
     name: "Markdownlint",
     packageName: "markdownlint-cli",
-    check: () => execAndParse(bin, checkArgs, root, parseOutput),
-    fix: () => execAndParse(bin, fixArgs, root, parseOutput),
+    check: () => execAndParse(checkCmd, root, parseOutput),
+    fix: () => execAndParse(fixCmd, root, parseOutput),
   };
 };
 

--- a/src/tools/oxlint.ts
+++ b/src/tools/oxlint.ts
@@ -2,23 +2,15 @@ import type { OutputParser, Problem, ToolDefinition } from "../types";
 import { execAndParse } from "../utils";
 
 export const oxlint: ToolDefinition = ({ root }) => {
-  const bin = "oxlint";
-  const checkArgs = [
-    "--format=unix",
-    "--deny-warnings",
-    "--ignore-path=.oxlintignore",
-    "--ignore-pattern='**/dist/**'",
-    "--ignore-pattern='**/node_modules/**'",
-    "--ignore-pattern='**/.output/**'",
-    "--ignore-pattern='**/coverage/**'",
-  ];
-  const fixArgs = [...checkArgs, "--fix"];
+  const checkCmd =
+    "oxlint . --format=unix --deny-warnings --ignore-path=.oxlintignore --ignore-pattern='**/dist/**' --ignore-pattern='**/node_modules/**' --ignore-pattern='**/.output/**' --ignore-pattern='**/coverage/**'";
+  const fixCmd = `${checkCmd} --fix`;
 
   return {
     name: "Oxlint",
     packageName: "oxlint",
-    check: () => execAndParse(bin, checkArgs, root, parseOutput),
-    fix: () => execAndParse(bin, fixArgs, root, parseOutput),
+    check: () => execAndParse(checkCmd, root, parseOutput),
+    fix: () => execAndParse(fixCmd, root, parseOutput),
   };
 };
 

--- a/src/tools/prettier.ts
+++ b/src/tools/prettier.ts
@@ -2,15 +2,14 @@ import type { OutputParser, Problem, ToolDefinition } from "../types";
 import { execAndParse } from "../utils";
 
 export const prettier: ToolDefinition = ({ root }) => {
-  const bin = "prettier";
-  const checkArgs = [".", "--list-different"];
-  const fixArgs = [".", "-w"];
+  const checkCmd = "prettier . --list-different";
+  const fixCmd = "prettier . -w";
 
   return {
     name: "Prettier",
     packageName: "prettier",
-    check: () => execAndParse(bin, checkArgs, root, parseOutput),
-    fix: () => execAndParse(bin, fixArgs, root, parseOutput),
+    check: () => execAndParse(checkCmd, root, parseOutput),
+    fix: () => execAndParse(fixCmd, root, parseOutput),
   };
 };
 

--- a/src/tools/publint.ts
+++ b/src/tools/publint.ts
@@ -7,13 +7,12 @@ import type {
 import { execAndParse } from "../utils";
 
 export const publint: ToolDefinition = ({ root }) => {
-  const bin = "publint";
-  const args: string[] = [];
+  const cmd = "publint";
 
   return {
     name: "Publint",
     packageName: "publint",
-    check: () => execAndParse(bin, args, root, parseOutput),
+    check: () => execAndParse(cmd, root, parseOutput),
   };
 };
 

--- a/src/tools/typescript.ts
+++ b/src/tools/typescript.ts
@@ -7,25 +7,22 @@ export const typescript: ToolDefinition = async ({
 }): Promise<Tool> => {
   const tsc = {
     name: "TypeScript",
-    bin: "tsc",
+    cmd: "tsc --noEmit --pretty false",
     packageName: "typescript",
-    args: ["--noEmit", "--pretty", "false"],
   };
   const vueTsc = {
     name: "TypeScript (Vue)",
-    bin: "vue-tsc",
+    cmd: "vue-tsc --noEmit --pretty false",
     packageName: "vue-tsc",
-    args: ["--noEmit", "--pretty", "false"],
   };
 
   const isVueTsc = packageJson.devDependencies?.["vue-tsc"] !== undefined;
   debug("TypeScript: Is vue-tsc installed? " + isVueTsc);
-  const cmd = isVueTsc ? vueTsc : tsc;
+  const mod = isVueTsc ? vueTsc : tsc;
   return {
-    name: cmd.name,
-    packageName: cmd.packageName,
-    // Execute the other TSC binary if necessary
-    check: async () => execAndParse(cmd.bin, cmd.args, root, parseOutput),
+    name: mod.name,
+    packageName: mod.packageName,
+    check: async () => execAndParse(mod.cmd, root, parseOutput),
   };
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,11 +3,10 @@ import type { OutputParser, Problem } from "./types";
 
 function exec(
   cmd: string,
-  args: string[],
   opts?: { cwd?: string },
 ): Promise<{ stderr: string; stdout: string; exitCode: number | null }> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { ...opts, shell: true });
+    const child = spawn(cmd, { ...opts, shell: true });
     let stderr = "";
     let stdout = "";
     child.stdout.on("data", (data) => {
@@ -26,14 +25,13 @@ function exec(
 }
 
 export async function execAndParse(
-  bin: string,
-  args: string[],
+  cmd: string,
   cwd: string,
   parser: OutputParser,
 ): Promise<Problem[]> {
-  const res = await exec(bin, args, { cwd });
+  const res = await exec(cmd, { cwd });
   if (res.exitCode == null) throw Error("Exit code was null");
-  if (isDebug()) console.debug({ bin, args, cwd, ...res });
+  if (isDebug()) console.debug({ cmd, cwd, ...res });
   return parser({
     code: res.exitCode,
     stderr: res.stderr,


### PR DESCRIPTION
Resolves: https://nodejs.org/api/deprecations.html#dep0190-passing-args-to-nodechild_process-execfilespawn-with-shell-option-true

Solution: https://github.com/nodejs/node/issues/58763#issuecomment-3005576831

There's not dynamic values in the commands ran, so no risk of injection. This just silences the warning from node.